### PR TITLE
Update Rust edition and modify environment variable handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-cli-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,9 @@ fn main() -> Result<()> {
     logs::init_tracing();
     let opt = Opt::parse();
     if opt.color {
+        unsafe {
         std::env::set_var("CLICOLOR_FORCE", "1");
+        }
     }
     match opt.cmd {
         Command::Do { something } => unimplemented!("{}", something),


### PR DESCRIPTION
Update the Rust edition in the Cargo.toml file to 2024 and wrap the environment variable setting in an unsafe block for safety.